### PR TITLE
JWT 추가 후 Account API에서 사용

### DIFF
--- a/src/main/java/com/example/tiggle/config/SecurityConfig.java
+++ b/src/main/java/com/example/tiggle/config/SecurityConfig.java
@@ -1,16 +1,23 @@
 package com.example.tiggle.config;
 
+import com.example.tiggle.security.jwt.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -21,10 +28,14 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
             .csrf(csrf -> csrf.disable())
+            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(authorize -> authorize
-                .requestMatchers("/**").permitAll()
+                .requestMatchers("/api/user/join", "/api/user/login").permitAll()
+                .requestMatchers("/swagger-ui/**", "/api-docs/**").permitAll()
+                .requestMatchers("/api/fintest/**").permitAll()
                 .anyRequest().authenticated()
-            );
+            )
+            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }
 }

--- a/src/main/java/com/example/tiggle/config/SwaggerConfig.java
+++ b/src/main/java/com/example/tiggle/config/SwaggerConfig.java
@@ -19,18 +19,12 @@ public class SwaggerConfig {
                         .description("'태산' 같은 변화를 만드는 금융 소셜 플랫폼 '티끌' API 문서")
                         .version("v0.1.0"))
                 .components(new Components()
-                        .addSecuritySchemes("encryptedUserKey", new SecurityScheme()
-                                .type(SecurityScheme.Type.APIKEY)
-                                .in(SecurityScheme.In.HEADER)
-                                .name("encryptedUserKey")
-                                .description("암호화된 사용자 키"))
-                        .addSecuritySchemes("userId", new SecurityScheme()
-                                .type(SecurityScheme.Type.APIKEY)
-                                .in(SecurityScheme.In.HEADER)
-                                .name("userId")
-                                .description("사용자 ID")))
+                        .addSecuritySchemes("bearerAuth", new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                                .description("JWT 토큰을 입력하세요")))
                 .addSecurityItem(new SecurityRequirement()
-                        .addList("encryptedUserKey")
-                        .addList("userId"));
+                        .addList("bearerAuth"));
     }
 }

--- a/src/main/java/com/example/tiggle/controller/account/AccountController.java
+++ b/src/main/java/com/example/tiggle/controller/account/AccountController.java
@@ -8,12 +8,13 @@ import com.example.tiggle.dto.account.response.OneWonVerificationValidateRespons
 import com.example.tiggle.dto.account.response.PrimaryAccountInfoDto;
 import com.example.tiggle.dto.common.ApiResponse;
 import com.example.tiggle.service.account.AccountService;
+import com.example.tiggle.util.JwtUtil;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import reactor.core.publisher.Mono;
 
 @RestController
 @RequestMapping("/api/accounts")
@@ -25,45 +26,67 @@ public class AccountController {
     
     @Operation(summary = "1원 송금 요청", description = "계좌번호로 1원 송금을 통한 계좌 인증을 수행합니다")
     @PostMapping("/verification")
-    public Mono<OneWonVerificationResponse> sendOneWonVerification(
-            @Parameter(description = "암호화된 사용자 키", required = true)
-            @RequestHeader("encryptedUserKey") String encryptedUserKey,
+    public ResponseEntity<OneWonVerificationResponse> sendOneWonVerification(
             @RequestBody OneWonVerificationRequest request) {
         
-        return accountService.sendOneWonVerification(encryptedUserKey, request.getAccountNo());
+        String encryptedUserKey = JwtUtil.getCurrentEncryptedUserKey();
+        
+        try {
+            OneWonVerificationResponse response = accountService.sendOneWonVerification(encryptedUserKey, request.getAccountNo()).block();
+            return ResponseEntity.ok(response);
+        } catch (Exception error) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(OneWonVerificationResponse.failure("서버 오류가 발생했습니다."));
+        }
     }
     
     @Operation(summary = "1원 송금 인증 코드 검증", description = "1원 송금으로 받은 인증 코드를 검증하고 검증 토큰을 발급합니다")
     @PostMapping("/verification/check")
-    public Mono<OneWonVerificationValidateResponse> validateOneWonAuth(
-            @Parameter(description = "암호화된 사용자 키", required = true)
-            @RequestHeader("encryptedUserKey") String encryptedUserKey,
-            @Parameter(description = "사용자 ID", required = true)
-            @RequestHeader("userId") Integer userId,
+    public ResponseEntity<OneWonVerificationValidateResponse> validateOneWonAuth(
             @RequestBody OneWonVerificationValidateRequest request) {
         
-        return accountService.validateOneWonAuth(encryptedUserKey, request.getAccountNo(), request.getAuthCode(), userId);
+        String encryptedUserKey = JwtUtil.getCurrentEncryptedUserKey();
+        Integer userId = JwtUtil.getCurrentUserId();
+        
+        try {
+            OneWonVerificationValidateResponse response = accountService.validateOneWonAuth(encryptedUserKey, request.getAccountNo(), request.getAuthCode(), userId).block();
+            return ResponseEntity.ok(response);
+        } catch (Exception error) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(OneWonVerificationValidateResponse.failure("서버 오류가 발생했습니다."));
+        }
     }
     
     @Operation(summary = "주 계좌 등록", description = "검증된 계좌를 주 계좌로 등록합니다")
     @PostMapping("/primary")
-    public Mono<ApiResponse<Void>> registerPrimaryAccount(
-            @Parameter(description = "사용자 ID", required = true)
-            @RequestHeader("userId") Integer userId,
+    public ResponseEntity<ApiResponse<Void>> registerPrimaryAccount(
             @RequestBody PrimaryAccountRequest request) {
         
-        return accountService.registerPrimaryAccount(
-                request.getAccountNo(), request.getVerificationToken(), userId);
+        Integer userId = JwtUtil.getCurrentUserId();
+        
+        try {
+            ApiResponse<Void> response = accountService.registerPrimaryAccount(
+                    request.getAccountNo(), request.getVerificationToken(), userId).block();
+            return ResponseEntity.ok(response);
+        } catch (Exception error) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(ApiResponse.<Void>failure("서버 오류가 발생했습니다."));
+        }
     }
     
     @Operation(summary = "주 계좌 조회", description = "등록된 주 계좌 정보를 조회합니다")
     @GetMapping("/primary")
-    public Mono<ApiResponse<PrimaryAccountInfoDto>> getPrimaryAccount(
-            @Parameter(description = "암호화된 사용자 키", required = true)
-            @RequestHeader("encryptedUserKey") String encryptedUserKey,
-            @Parameter(description = "사용자 ID", required = true)
-            @RequestHeader("userId") Integer userId) {
+    public ResponseEntity<ApiResponse<PrimaryAccountInfoDto>> getPrimaryAccount() {
         
-        return accountService.getPrimaryAccount(encryptedUserKey, userId);
+        String encryptedUserKey = JwtUtil.getCurrentEncryptedUserKey();
+        Integer userId = JwtUtil.getCurrentUserId();
+        
+        try {
+            ApiResponse<PrimaryAccountInfoDto> response = accountService.getPrimaryAccount(encryptedUserKey, userId).block();
+            return ResponseEntity.ok(response);
+        } catch (Exception error) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(ApiResponse.<PrimaryAccountInfoDto>failure("서버 오류가 발생했습니다."));
+        }
     }
 }

--- a/src/main/java/com/example/tiggle/controller/finopenapi/FinancialTestController.java
+++ b/src/main/java/com/example/tiggle/controller/finopenapi/FinancialTestController.java
@@ -4,8 +4,9 @@ import com.example.tiggle.dto.finopenapi.response.*;
 import com.example.tiggle.service.finopenapi.FinancialApiService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import reactor.core.publisher.Mono;
 
 @RestController
 @RequestMapping("/api/fintest")
@@ -19,132 +20,207 @@ public class FinancialTestController {
 
     @Operation(summary = "사용자 계정 생성", description = "새로운 사용자 계정을 생성합니다")
     @PostMapping("/user")
-    public Mono<UserResponse> createUser(@RequestParam String userId) {
-        return financialApiService.createUser(userId);
+    public ResponseEntity<UserResponse> createUser(@RequestParam String userId) {
+        try {
+            UserResponse response = financialApiService.createUser(userId).block();
+            return ResponseEntity.ok(response);
+        } catch (Exception error) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
     }
 
     @Operation(summary = "사용자 조회", description = "사용자 정보를 조회합니다")
     @GetMapping("/user/{userId}")
-    public Mono<UserResponse> searchUser(@PathVariable String userId) {
-        return financialApiService.searchUser(userId);
+    public ResponseEntity<UserResponse> searchUser(@PathVariable String userId) {
+        try {
+            UserResponse response = financialApiService.searchUser(userId).block();
+            return ResponseEntity.ok(response);
+        } catch (Exception error) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
     }
 
     @Operation(summary = "계좌 생성", description = "새로운 수시입출금 계좌를 생성합니다")
     @PostMapping("/account")
-    public Mono<CreateDemandDepositAccountResponse> createAccount(@RequestParam String userKey) {
-        return financialApiService.createDemandDepositAccount(userKey);
+    public ResponseEntity<CreateDemandDepositAccountResponse> createAccount(@RequestParam String userKey) {
+        try {
+            CreateDemandDepositAccountResponse response = financialApiService.createDemandDepositAccount(userKey).block();
+            return ResponseEntity.ok(response);
+        } catch (Exception error) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
     }
 
     @Operation(summary = "계좌 목록 조회", description = "사용자의 모든 계좌 목록을 조회합니다")
     @GetMapping("/accounts")
-    public Mono<InquireDemandDepositAccountListResponse> getAccountList(@RequestParam String userKey) {
-        return financialApiService.inquireDemandDepositAccountList(userKey);
+    public ResponseEntity<InquireDemandDepositAccountListResponse> getAccountList(@RequestParam String userKey) {
+        try {
+            InquireDemandDepositAccountListResponse response = financialApiService.inquireDemandDepositAccountList(userKey).block();
+            return ResponseEntity.ok(response);
+        } catch (Exception error) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
     }
 
     @Operation(summary = "계좌 잔액 조회", description = "특정 계좌의 현재 잔액을 조회합니다")
     @GetMapping("/account/balance")
-    public Mono<InquireDemandDepositAccountBalanceResponse> getAccountBalance(
+    public ResponseEntity<InquireDemandDepositAccountBalanceResponse> getAccountBalance(
             @RequestParam String userKey, 
             @RequestParam String accountNo) {
-        return financialApiService.inquireDemandDepositAccountBalance(userKey, accountNo);
+        try {
+            InquireDemandDepositAccountBalanceResponse response = financialApiService.inquireDemandDepositAccountBalance(userKey, accountNo).block();
+            return ResponseEntity.ok(response);
+        } catch (Exception error) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
     }
 
     @Operation(summary = "계좌 상세 조회", description = "특정 계좌의 상세 정보를 조회합니다")
     @GetMapping("/account/detail")
-    public Mono<InquireDemandDepositAccountResponse> getAccountDetail(
+    public ResponseEntity<InquireDemandDepositAccountResponse> getAccountDetail(
             @RequestParam String userKey, 
             @RequestParam String accountNo) {
-        return financialApiService.inquireDemandDepositAccount(userKey, accountNo);
+        try {
+            InquireDemandDepositAccountResponse response = financialApiService.inquireDemandDepositAccount(userKey, accountNo).block();
+            return ResponseEntity.ok(response);
+        } catch (Exception error) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
     }
 
     @Operation(summary = "계좌 입금", description = "특정 계좌에 금액을 입금합니다")
     @PostMapping("/account/deposit")
-    public Mono<UpdateDemandDepositAccountDepositResponse> deposit(
+    public ResponseEntity<UpdateDemandDepositAccountDepositResponse> deposit(
             @RequestParam String userKey,
             @RequestParam String accountNo,
             @RequestParam String transactionBalance,
             @RequestParam String transactionSummary) {
-        return financialApiService.updateDemandDepositAccountDeposit(userKey, accountNo, transactionBalance, transactionSummary);
+        try {
+            UpdateDemandDepositAccountDepositResponse response = financialApiService.updateDemandDepositAccountDeposit(userKey, accountNo, transactionBalance, transactionSummary).block();
+            return ResponseEntity.ok(response);
+        } catch (Exception error) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
     }
 
     @Operation(summary = "계좌 출금", description = "특정 계좌에서 금액을 출금합니다")
     @PostMapping("/account/withdraw")
-    public Mono<UpdateDemandDepositAccountWithdrawalResponse> withdraw(
+    public ResponseEntity<UpdateDemandDepositAccountWithdrawalResponse> withdraw(
             @RequestParam String userKey,
             @RequestParam String accountNo,
             @RequestParam String transactionBalance,
             @RequestParam String transactionSummary) {
-        return financialApiService.updateDemandDepositAccountWithdrawal(userKey, accountNo, transactionBalance, transactionSummary);
+        try {
+            UpdateDemandDepositAccountWithdrawalResponse response = financialApiService.updateDemandDepositAccountWithdrawal(userKey, accountNo, transactionBalance, transactionSummary).block();
+            return ResponseEntity.ok(response);
+        } catch (Exception error) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
     }
 
     @Operation(summary = "계좌 이체", description = "한 계좌에서 다른 계좌로 금액을 이체합니다")
     @PostMapping("/account/transfer")
-    public Mono<UpdateDemandDepositAccountTransferResponse> transfer(
+    public ResponseEntity<UpdateDemandDepositAccountTransferResponse> transfer(
             @RequestParam String userKey,
             @RequestParam String depositAccountNo,
             @RequestParam String depositTransactionSummary,
             @RequestParam String transactionBalance,
             @RequestParam String withdrawalAccountNo,
             @RequestParam String withdrawalTransactionSummary) {
-        return financialApiService.updateDemandDepositAccountTransfer(
-                userKey, depositAccountNo, depositTransactionSummary, 
-                transactionBalance, withdrawalAccountNo, withdrawalTransactionSummary);
+        try {
+            UpdateDemandDepositAccountTransferResponse response = financialApiService.updateDemandDepositAccountTransfer(
+                    userKey, depositAccountNo, depositTransactionSummary, 
+                    transactionBalance, withdrawalAccountNo, withdrawalTransactionSummary).block();
+            return ResponseEntity.ok(response);
+        } catch (Exception error) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
     }
 
     @Operation(summary = "계좌 거래 내역 조회", description = "특정 계좌의 거래 내역을 조회합니다")
     @GetMapping("/account/transactions")
-    public Mono<InquireTransactionHistoryListResponse> getTransactionHistory(
+    public ResponseEntity<InquireTransactionHistoryListResponse> getTransactionHistory(
             @RequestParam String userKey,
             @RequestParam String accountNo,
             @RequestParam String startDate,
             @RequestParam String endDate,
             @RequestParam String transactionType,
             @RequestParam String orderByType) {
-        return financialApiService.inquireTransactionHistoryList(
-                userKey, accountNo, startDate, endDate, transactionType, orderByType);
+        try {
+            InquireTransactionHistoryListResponse response = financialApiService.inquireTransactionHistoryList(
+                    userKey, accountNo, startDate, endDate, transactionType, orderByType).block();
+            return ResponseEntity.ok(response);
+        } catch (Exception error) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
     }
 
     @Operation(summary = "계좌 거래 내역 조회(단건)", description = "특정 거래의 상세 정보를 조회합니다")
     @GetMapping("/account/transaction")
-    public Mono<InquireTransactionHistoryResponse> getTransaction(
+    public ResponseEntity<InquireTransactionHistoryResponse> getTransaction(
             @RequestParam String userKey,
             @RequestParam String accountNo,
             @RequestParam String transactionUniqueNo) {
-        return financialApiService.inquireTransactionHistory(userKey, accountNo, transactionUniqueNo);
+        try {
+            InquireTransactionHistoryResponse response = financialApiService.inquireTransactionHistory(userKey, accountNo, transactionUniqueNo).block();
+            return ResponseEntity.ok(response);
+        } catch (Exception error) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
     }
 
     @Operation(summary = "계좌 해지", description = "특정 계좌를 해지합니다")
     @DeleteMapping("/account")
-    public Mono<DeleteDemandDepositAccountResponse> deleteAccount(
+    public ResponseEntity<DeleteDemandDepositAccountResponse> deleteAccount(
             @RequestParam String userKey,
             @RequestParam String accountNo) {
-        return financialApiService.deleteDemandDepositAccount(userKey, accountNo);
+        try {
+            DeleteDemandDepositAccountResponse response = financialApiService.deleteDemandDepositAccount(userKey, accountNo).block();
+            return ResponseEntity.ok(response);
+        } catch (Exception error) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
     }
 
     @Operation(summary = "1원 송금(계좌 인증)", description = "계좌 인증을 위한 1원 송금을 실행합니다")
     @PostMapping("/account/auth")
-    public Mono<OpenAccountAuthResponse> openAccountAuth(
+    public ResponseEntity<OpenAccountAuthResponse> openAccountAuth(
             @RequestParam String userKey,
             @RequestParam String accountNo,
             @RequestParam String authText) {
-        return financialApiService.openAccountAuth(userKey, accountNo, authText);
+        try {
+            OpenAccountAuthResponse response = financialApiService.openAccountAuth(userKey, accountNo, authText).block();
+            return ResponseEntity.ok(response);
+        } catch (Exception error) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
     }
 
     @Operation(summary = "1원 송금 인증 검증", description = "1원 송금 인증 코드를 검증합니다")
     @PostMapping("/account/auth/verify")
-    public Mono<CheckAuthCodeResponse> checkAuthCode(
+    public ResponseEntity<CheckAuthCodeResponse> checkAuthCode(
             @RequestParam String userKey,
             @RequestParam String accountNo,
             @RequestParam String authText,
             @RequestParam String authCode) {
-        return financialApiService.checkAuthCode(userKey, accountNo, authText, authCode);
+        try {
+            CheckAuthCodeResponse response = financialApiService.checkAuthCode(userKey, accountNo, authText, authCode).block();
+            return ResponseEntity.ok(response);
+        } catch (Exception error) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
     }
     
     @Operation(summary = "계좌 소유자명 조회", description = "계좌의 소유자명을 조회합니다")
     @GetMapping("/account/holder")
-    public Mono<InquireDemandDepositAccountHolderNameResponse> getAccountHolderName(
+    public ResponseEntity<InquireDemandDepositAccountHolderNameResponse> getAccountHolderName(
             @RequestParam String userKey,
             @RequestParam String accountNo) {
-        return financialApiService.inquireDemandDepositAccountHolderName(userKey, accountNo);
+        try {
+            InquireDemandDepositAccountHolderNameResponse response = financialApiService.inquireDemandDepositAccountHolderName(userKey, accountNo).block();
+            return ResponseEntity.ok(response);
+        } catch (Exception error) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
     }
 }

--- a/src/main/java/com/example/tiggle/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/example/tiggle/security/jwt/JwtTokenProvider.java
@@ -42,7 +42,7 @@ public class JwtTokenProvider {
 
     public Claims getClaimsFromToken(String token) {
         try {
-            return Jwts.parser().setSigningKey(key).build().parseClaimsJws(token).getBody();
+            return Jwts.parser().verifyWith((javax.crypto.SecretKey) key).build().parseClaimsJws(token).getBody();
         } catch (ExpiredJwtException ex) {
             throw new UserAuthException("JWT_EXPIRED", "토큰이 만료되었습니다.");
         } catch (UnsupportedJwtException ex) {

--- a/src/main/java/com/example/tiggle/service/account/AccountVerificationTokenService.java
+++ b/src/main/java/com/example/tiggle/service/account/AccountVerificationTokenService.java
@@ -8,6 +8,8 @@ public interface AccountVerificationTokenService {
     
     boolean validateToken(String token);
     
+    boolean validateTokenForAccount(String token, String accountNo);
+    
     void markTokenAsUsed(String token);
     
     void cleanupExpiredTokens();

--- a/src/main/java/com/example/tiggle/util/JwtUtil.java
+++ b/src/main/java/com/example/tiggle/util/JwtUtil.java
@@ -1,0 +1,24 @@
+package com.example.tiggle.util;
+
+import com.example.tiggle.security.jwt.CustomUserDetails;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+
+public class JwtUtil {
+
+    public static Integer getCurrentUserId() {
+        UserDetails userDetails = (UserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        if (userDetails instanceof CustomUserDetails) {
+            return ((CustomUserDetails) userDetails).getUserId();
+        }
+        throw new IllegalStateException("인증된 사용자 정보를 찾을 수 없습니다.");
+    }
+
+    public static String getCurrentEncryptedUserKey() {
+        UserDetails userDetails = (UserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        if (userDetails instanceof CustomUserDetails) {
+            return ((CustomUserDetails) userDetails).getEncryptedUserKey();
+        }
+        throw new IllegalStateException("인증된 사용자의 암호화된 키를 찾을 수 없습니다.");
+    }
+}


### PR DESCRIPTION
<!-- 줄바꿈 형식 지켜주세요. 다음과 같습니다.
## title1
title1 관련 주석
- title1 관련 내용1
- title1 관련 내용2

<br>

## title2
title2 관련 주석
title2 관련 내용
-->
## 📄 요약 (Summary)
<!-- 이번 PR에서 어떤 작업을 했는지 간단하게 설명해주세요. -->
추가된 JWT 설정을 Account API에서 사용하도록 변경했습니다.
JWT에 있는 userId와 암호화 userKey를 가져와서 복호화해서 사용합니다.

<br>

## 🔗 관련 이슈 (Related Issue)
<!-- 본 PR과 관련된 Jira 이슈 번호를 모두 적어주세요. -->
- Closes OPS-61
 
<br>

## ✨ 주요 변경 사항 (Key Changes)
<!-- 이번 PR에서 중점적으로 봐야 할 변경 사항을 목록으로 작성해주세요. -->
<!-- 리스트 형식으로 작성해주세요. -->
<!-- - (예시) 로그인 시 JWT 토큰을 발급하는 로직 추가 --> 
<!-- - (예시) 사용자 데이터베이스 스키마에 `last_login` 필드를 추가 -->
<!-- - (예시) 로그인 실패 시 에러 처리 로직을 보강 -->
- JWT에서 userId와 userKey 가져오는 util 추가
- swagger에 jwt 토큰 넣을 수 있도록 Header 설정 변경
- 인증 없이 사용할 수 있는 API 설정
- Controller 반환타입 Mono->ResponseEntity로 변경
- 1원 인증 완료 후 계좌 검증 토큰에서 계좌 검증 로직 추가
- AccountService에서 userKey 복호화 해서 사용하는 것으로 변경

<br>

## 🙏 리뷰어에게 (To the Reviewer)
<!-- 리뷰어가 특별히 신경 써서 봐주었으면 하는 부분이나, 테스트 시 참고할 사항이 있다면 알려주세요. -->
<!-- 최대한 작성해 주시되 없으면 X라고 써주세요. -->
<!-- - (예시) User 모델의 변경 사항이 DB 마이그레이션에 영향을 줄 수 있으니 이 부분을 중점적으로 봐주세요. -->
JWT를 추가한 후에 Mono를 사용한 API들에 403 에러가 발생했습니다.
Mono가 비동기적으로 처리하다보니 Spring Security의 인증 정보가 전파되지 않아서 403 에러가 발생한 것으로 추측됩니다.
따라서 .block()으로 동기 처리하고 ResponseEntity로 반환하도록 수정하였습니다.
