### PR TITLE
예금주 조회 API 구현

### DIFF
--- a/src/main/java/com/example/tiggle/controller/account/AccountController.java
+++ b/src/main/java/com/example/tiggle/controller/account/AccountController.java
@@ -3,6 +3,7 @@ package com.example.tiggle.controller.account;
 import com.example.tiggle.dto.account.request.OneWonVerificationRequest;
 import com.example.tiggle.dto.account.request.OneWonVerificationValidateRequest;
 import com.example.tiggle.dto.account.request.PrimaryAccountRequest;
+import com.example.tiggle.dto.account.response.AccountHolderInfoDto;
 import com.example.tiggle.dto.account.response.OneWonVerificationResponse;
 import com.example.tiggle.dto.account.response.OneWonVerificationValidateResponse;
 import com.example.tiggle.dto.account.response.PrimaryAccountInfoDto;
@@ -70,7 +71,7 @@ public class AccountController {
             return ResponseEntity.ok(response);
         } catch (Exception error) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(ApiResponse.<Void>failure("서버 오류가 발생했습니다."));
+                    .body(ApiResponse.failure("서버 오류가 발생했습니다."));
         }
     }
     
@@ -86,7 +87,23 @@ public class AccountController {
             return ResponseEntity.ok(response);
         } catch (Exception error) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(ApiResponse.<PrimaryAccountInfoDto>failure("서버 오류가 발생했습니다."));
+                    .body(ApiResponse.failure("서버 오류가 발생했습니다."));
+        }
+    }
+    
+    @Operation(summary = "예금주 조회", description = "계좌번호로 예금주 정보를 조회합니다")
+    @GetMapping("/holder")
+    public ResponseEntity<ApiResponse<AccountHolderInfoDto>> getAccountHolder(
+            @RequestParam String accountNo) {
+        
+        String encryptedUserKey = JwtUtil.getCurrentEncryptedUserKey();
+        
+        try {
+            ApiResponse<AccountHolderInfoDto> response = accountService.getAccountHolder(encryptedUserKey, accountNo).block();
+            return ResponseEntity.ok(response);
+        } catch (Exception error) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(ApiResponse.failure("서버 오류가 발생했습니다."));
         }
     }
 }

--- a/src/main/java/com/example/tiggle/dto/account/response/AccountHolderInfoDto.java
+++ b/src/main/java/com/example/tiggle/dto/account/response/AccountHolderInfoDto.java
@@ -1,0 +1,20 @@
+package com.example.tiggle.dto.account.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "예금주 정보 DTO")
+public class AccountHolderInfoDto {
+    
+    @Schema(description = "은행명", example = "신한은행")
+    private String bankName;
+    
+    @Schema(description = "계좌번호", example = "0888315782686732")
+    private String accountNo;
+    
+    @Schema(description = "예금주명", example = "홍길동")
+    private String userName;
+}

--- a/src/main/java/com/example/tiggle/service/account/AccountService.java
+++ b/src/main/java/com/example/tiggle/service/account/AccountService.java
@@ -1,5 +1,6 @@
 package com.example.tiggle.service.account;
 
+import com.example.tiggle.dto.account.response.AccountHolderInfoDto;
 import com.example.tiggle.dto.account.response.OneWonVerificationResponse;
 import com.example.tiggle.dto.account.response.OneWonVerificationValidateResponse;
 import com.example.tiggle.dto.account.response.PrimaryAccountInfoDto;
@@ -15,4 +16,6 @@ public interface AccountService {
     Mono<ApiResponse<Void>> registerPrimaryAccount(String accountNo, String verificationToken, Integer userId);
     
     Mono<ApiResponse<PrimaryAccountInfoDto>> getPrimaryAccount(String encryptedUserKey, Integer userId);
+    
+    Mono<ApiResponse<AccountHolderInfoDto>> getAccountHolder(String encryptedUserKey, String accountNo);
 }


### PR DESCRIPTION
<!-- 줄바꿈 형식 지켜주세요. 다음과 같습니다.
## title1
title1 관련 주석
- title1 관련 내용1
- title1 관련 내용2

<br>

## title2
title2 관련 주석
title2 관련 내용
-->
## 📄 요약 (Summary)
<!-- 이번 PR에서 어떤 작업을 했는지 간단하게 설명해주세요. -->
예금주 조회 API 구현

<br>

## 🔗 관련 이슈 (Related Issue)
<!-- 본 PR과 관련된 Jira 이슈 번호를 모두 적어주세요. -->
- Closes OPS-67
 
<br>

## ✨ 주요 변경 사항 (Key Changes)
<!-- 이번 PR에서 중점적으로 봐야 할 변경 사항을 목록으로 작성해주세요. -->
<!-- 리스트 형식으로 작성해주세요. -->
<!-- - (예시) 로그인 시 JWT 토큰을 발급하는 로직 추가 --> 
<!-- - (예시) 사용자 데이터베이스 스키마에 `last_login` 필드를 추가 -->
<!-- - (예시) 로그인 실패 시 에러 처리 로직을 보강 -->
- 예금주 조회 응답 DTO 구현
- 예금주 조회 Service Layer 구현
- 예금주 조회 Controller 구현

<br>

## 🙏 리뷰어에게 (To the Reviewer)
<!-- 리뷰어가 특별히 신경 써서 봐주었으면 하는 부분이나, 테스트 시 참고할 사항이 있다면 알려주세요. -->
<!-- 최대한 작성해 주시되 없으면 X라고 써주세요. -->
<!-- - (예시) User 모델의 변경 사항이 DB 마이그레이션에 영향을 줄 수 있으니 이 부분을 중점적으로 봐주세요. -->
SSAFY 금융 API에서는 username을 email의 유저명만 쓰고 있습니다. (예: user@test.com에서 user)
그래서 바로 사용하지 못하고 우리 서버에서 Account 테이블을 만들어서 금융 서버와 동기화 하는 방식으로 사용해야 할 것 같습니다.
응답 형식이 바뀌진 않으니 프론트와의 협업을 위해 먼저 병합한 후에 추후 수정하겠습니다.
