### PR TITLE
feat : 터널링 후 DB 접속 연결하도록 수정

### DIFF
--- a/src/main/java/com/example/tiggle/config/SshTunnelConfig.java
+++ b/src/main/java/com/example/tiggle/config/SshTunnelConfig.java
@@ -1,68 +1,156 @@
 package com.example.tiggle.config;
 
-import org.springframework.boot.ApplicationRunner;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 
-import java.io.File;
+import jakarta.persistence.EntityManagerFactory;
+import javax.sql.DataSource;
+import java.io.*;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.nio.file.*;
+import java.util.*;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
 
 @Configuration
 @Profile("local")
 public class SshTunnelConfig {
 
     @Bean
-    public ApplicationRunner sshTunnelRunner() {
-        return args -> {
-            try {
-                String os = System.getProperty("os.name").toLowerCase();
-                ProcessBuilder pb;
-                
-                if (os.contains("windows")) {
-                    pb = new ProcessBuilder("ssh", "-i", "taesan.pem", "-N", 
-                            "-L", "13306:127.0.0.1:3306", 
-                            "-L", "16379:127.0.0.1:6379",
-                            "-o", "ExitOnForwardFailure=yes",
-                            "-o", "ServerAliveInterval=60",
-                            "ubuntu@ec2-43-203-36-96.ap-northeast-2.compute.amazonaws.com");
-                } else {
-                    pb = new ProcessBuilder("ssh", "-i", "./taesan.pem", "-N",
-                            "-L", "13306:127.0.0.1:3306",
-                            "-L", "16379:127.0.0.1:6379", 
-                            "-o", "ExitOnForwardFailure=yes",
-                            "-o", "ServerAliveInterval=60",
-                            "ubuntu@ec2-43-203-36-96.ap-northeast-2.compute.amazonaws.com");
-                }
-                
-                pb.directory(new File("."));
-                
-                // 이미 실행중인 터널이 있는지 확인
-                if (!isTunnelRunning()) {
-                    System.out.println("Starting SSH tunnel...");
-                    Process process = pb.start();
-                    
-                    // 터널이 설정될 때까지 잠시 대기
-                    Thread.sleep(3000);
-                    System.out.println("SSH tunnel established");
-                } else {
-                    System.out.println("SSH tunnel already running");
-                }
-                
-            } catch (Exception e) {
-                System.err.println("Failed to start SSH tunnel: " + e.getMessage());
+    public static BeanFactoryPostProcessor dataSourceDependsOnSshTunnel() {
+        return (ConfigurableListableBeanFactory bf) -> {
+            for (String name : bf.getBeanNamesForType(DataSource.class, true, false)) {
+                BeanDefinition bd = bf.getBeanDefinition(name);
+                bd.setDependsOn(appendDependsOn(bd.getDependsOn(), "sshTunnelStarter"));
+            }
+            for (String name : bf.getBeanNamesForType(EntityManagerFactory.class, true, false)) {
+                BeanDefinition bd = bf.getBeanDefinition(name);
+                bd.setDependsOn(appendDependsOn(bd.getDependsOn(), "sshTunnelStarter"));
+            }
+            for (String name : bf.getBeanNamesForType(RedisConnectionFactory.class, true, false)) {
+                BeanDefinition bd = bf.getBeanDefinition(name);
+                bd.setDependsOn(appendDependsOn(bd.getDependsOn(), "sshTunnelStarter"));
             }
         };
     }
-    
-    private boolean isTunnelRunning() {
+
+    private static String[] appendDependsOn(String[] current, String beanName) {
+        if (current == null || current.length == 0) return new String[]{beanName};
+        String[] next = Arrays.copyOf(current, current.length + 1);
+        next[next.length - 1] = beanName;
+        return next;
+    }
+
+    @Bean(name = "sshTunnelStarter")
+    public Object sshTunnelStarterBean() {
+        startSshTunnel();
+        return new Object();
+    }
+
+    private void startSshTunnel() {
         try {
-            ProcessBuilder pb = new ProcessBuilder("netstat", "-an");
-            Process process = pb.start();
-            
-            String output = new String(process.getInputStream().readAllBytes());
-            return output.contains(":13306") && output.contains(":16379");
+            String os = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
+            boolean isWindows = os.contains("windows");
+            String knownHostsSink = isWindows ? "NUL" : "/dev/null";
+
+            Path pem = resolvePemPath();
+            System.out.println("[SSH] Using PEM: " + pem.toAbsolutePath());
+
+            String sshExe = resolveSshExecutable(isWindows);
+            System.out.println("[SSH] Using SSH: " + sshExe);
+
+            if (isListening("127.0.0.1", 13306) && isListening("127.0.0.1", 16379)) {
+                System.out.println("[SSH] Tunnel already listening");
+                return;
+            }
+
+            List<String> cmd = new ArrayList<>(List.of(
+                    sshExe,
+                    "-i", pem.toAbsolutePath().toString(),
+                    "-N",
+                    "-L", "13306:127.0.0.1:3306",
+                    "-L", "16379:127.0.0.1:6379",
+                    "-o", "ExitOnForwardFailure=yes",
+                    "-o", "ServerAliveInterval=60",
+                    "-o", "BatchMode=yes",
+                    "-o", "ConnectTimeout=10",
+                    "-o", "StrictHostKeyChecking=no",
+                    "-o", "UserKnownHostsFile=" + knownHostsSink,
+                    "ubuntu@ec2-43-203-36-96.ap-northeast-2.compute.amazonaws.com"
+            ));
+            System.out.println("[SSH] Starting: " + String.join(" ", cmd));
+
+            ProcessBuilder pb = new ProcessBuilder(cmd);
+            pb.directory(pem.getParent() != null ? pem.getParent().toFile() : new File("."));
+            pb.redirectErrorStream(true);
+
+            Process p = pb.start();
+
+            new Thread(() -> {
+                try (InputStream in = p.getInputStream()) { in.transferTo(System.out); }
+                catch (Exception ignored) {}
+            }, "ssh-log").start();
+
+            long end = System.currentTimeMillis() + 30_000;
+            while (System.currentTimeMillis() < end) {
+                if (isListening("127.0.0.1", 13306) && isListening("127.0.0.1", 16379)) {
+                    System.out.println("[SSH] Tunnel established");
+                    return;
+                }
+                if (!p.isAlive()) {
+                    throw new IllegalStateException("ssh exited early, code=" + p.exitValue());
+                }
+                Thread.sleep(300);
+            }
+            throw new IllegalStateException("Ports not open within timeout. See ssh-log above.");
         } catch (Exception e) {
-            return false;
+            throw new IllegalStateException("Failed to start SSH tunnel: " + e.getMessage(), e);
         }
+    }
+
+    private Path resolvePemPath() {
+        String override = System.getProperty("ssh.pem");
+        if (override == null || override.isBlank()) override = System.getenv("SSH_PEM_PATH");
+        if (override != null && !override.isBlank()) {
+            Path p = toAbs(override); requireReadable(p); return p;
+        }
+        String[] candidates = { "taesan.pem", "./taesan.pem", "keys/taesan.pem" };
+        for (String c : candidates) {
+            Path p = toAbs(c);
+            if (Files.isRegularFile(p) && Files.isReadable(p)) return p;
+        }
+        throw new IllegalStateException("PEM not found. Set -Dssh.pem or SSH_PEM_PATH, or place taesan.pem in working dir: " +
+                Paths.get("").toAbsolutePath());
+    }
+    private Path toAbs(String in) {
+        if (in.startsWith("~")) in = System.getProperty("user.home")+in.substring(1);
+        Path p = Paths.get(in);
+        if (!p.isAbsolute()) p = Paths.get(System.getProperty("user.dir")).resolve(p).normalize();
+        return p;
+    }
+    private void requireReadable(Path p) {
+        if (!Files.isRegularFile(p) || !Files.isReadable(p))
+            throw new IllegalStateException("PEM not readable: " + p.toAbsolutePath());
+    }
+    private String resolveSshExecutable(boolean isWindows) {
+        if (isWindows) {
+            try {
+                Process pr = new ProcessBuilder("where", "ssh").start();
+                if (pr.waitFor() == 0) try (BufferedReader br = new BufferedReader(new InputStreamReader(pr.getInputStream()))) {
+                    String line = br.readLine();
+                    if (line != null && !line.isBlank()) return line.trim();
+                }
+            } catch (Exception ignored) {}
+            return "C:\\Windows\\System32\\OpenSSH\\ssh.exe";
+        }
+        return "ssh";
+    }
+    private boolean isListening(String host, int port) {
+        try (Socket s = new Socket()) { s.connect(new InetSocketAddress(host, port), 200); return true; }
+        catch (Exception e) { return false; }
     }
 }


### PR DESCRIPTION
## 📄 요약 (Summary)

이전에 터널링이 되기 전 DB/Redis 접속을 시도하여 에러가 발생하는 부분을 수정했습니다.

<br>

## 🔗 관련 이슈 (Related Issue)
X

<br>

## ✨ 주요 변경 사항 (Key Changes)

* `@Profile("local")` 환경에서만 동작하는 SSH 터널 실행 로직 정비
* `taesan.pem` 키 파일을 **프로젝트 루트 기준으로 탐색**하도록 경로 처리 보강
* MySQL(13306), Redis(16379) 포트 포워딩 및 **기존 터널 중복 실행 방지** 체크 추가
* 로컬 접속용 환경변수/프로퍼티 예시 정리(127.0.0.1:13306, 127.0.0.1:16379)

<br>

## 🙏 리뷰어에게 (To the Reviewer)
X
