### PR TITLE
더치페이 FCM 클릭 시 상세 조회 API 구현

### DIFF
--- a/src/main/java/com/example/tiggle/controller/auth/SmsController.java
+++ b/src/main/java/com/example/tiggle/controller/auth/SmsController.java
@@ -1,7 +1,7 @@
 package com.example.tiggle.controller.auth;
 
 import com.example.tiggle.dto.ResponseDto;
-import com.example.tiggle.service.SmsService;
+import com.example.tiggle.service.sms.SmsService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.constraints.NotBlank;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/example/tiggle/controller/dutchpay/DutchpayController.java
+++ b/src/main/java/com/example/tiggle/controller/dutchpay/DutchpayController.java
@@ -2,6 +2,8 @@ package com.example.tiggle.controller.dutchpay;
 
 import com.example.tiggle.dto.ResponseDto;
 import com.example.tiggle.dto.dutchpay.request.CreateDutchpayRequest;
+import com.example.tiggle.dto.dutchpay.request.DutchpayDetailData;
+import com.example.tiggle.service.dutchpay.DutchpayReadService;
 import com.example.tiggle.service.dutchpay.DutchpayService;
 import com.example.tiggle.util.JwtUtil;
 import io.swagger.v3.oas.annotations.Operation;
@@ -24,6 +26,7 @@ import org.springframework.web.server.ResponseStatusException;
 public class DutchpayController {
 
     private final DutchpayService dutchpayService;
+    private final DutchpayReadService dutchpayReadService;
 
     @PostMapping("/requests")
     @Operation(summary = "더치페이 요청 생성(저장 + FCM 발송)")
@@ -41,4 +44,12 @@ public class DutchpayController {
         dutchpayService.create(creatorId, req);
         return ResponseEntity.ok(new ResponseDto<>(true));
     }
+
+    @GetMapping("/{id}/detail")
+    @Operation(summary = "더치페이 요청 상세 페이지 조회")
+    public ResponseEntity<ResponseDto<DutchpayDetailData>> getDetail(@PathVariable("id") Long dutchpayId) {
+        Long userId = JwtUtil.getCurrentUserId();
+        return ResponseEntity.ok(dutchpayReadService.getDetail(dutchpayId, userId));
+    }
+
 }

--- a/src/main/java/com/example/tiggle/dto/dutchpay/request/DutchpayDetailData.java
+++ b/src/main/java/com/example/tiggle/dto/dutchpay/request/DutchpayDetailData.java
@@ -1,0 +1,21 @@
+package com.example.tiggle.dto.dutchpay.request;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDateTime;
+
+public record DutchpayDetailData(
+        Long dutchpayId,
+        String title,
+        String message,
+        String requesterName,
+        int participantCount,
+        Long totalAmount,
+        @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        LocalDateTime requestedAt,
+        Long myAmount,          // 100원 단위 올림된 "내가 내는 금액"
+        Long originalAmount,    // 올림 전 금액(예: 16666)
+        Long tiggleAmount,      // 티끌 = myAmount - originalAmount (예: 334)
+        Boolean payMoreDefault, // 자동 기부 기본값
+        Boolean creator         // 내가 생성자인지 여부
+) {}

--- a/src/main/java/com/example/tiggle/repository/dutchpay/DutchpayQueryRepository.java
+++ b/src/main/java/com/example/tiggle/repository/dutchpay/DutchpayQueryRepository.java
@@ -1,0 +1,33 @@
+package com.example.tiggle.repository.dutchpay;
+
+import com.example.tiggle.entity.Dutchpay;
+import com.example.tiggle.repository.dutchpay.projection.DutchpayDetailProjection;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
+
+public interface DutchpayQueryRepository extends Repository<Dutchpay, Long> {
+
+    @Query(value = """
+    SELECT
+        d.id                           AS dutchpayId,
+        d.title                        AS title,
+        d.message                      AS message,
+        u.name                         AS requesterName,   -- ← users.name 사용
+        (SELECT COUNT(*) FROM dutchpay_share s2 WHERE s2.dutchpay_id = d.id) AS participantCount,
+        d.total_amount                 AS totalAmount,
+        d.created_at                   AS createdAt,
+        COALESCE(s.amount, 0)          AS myAmount,
+        COALESCE(d.rounded_per_person, 0) AS originalAmount,
+        d.pay_more                     AS payMore,
+        d.creator_id                   AS creatorId
+    FROM dutchpay d
+    JOIN users u ON u.id = d.creator_id                   -- ← student → users 로 변경
+    LEFT JOIN dutchpay_share s ON s.dutchpay_id = d.id AND s.user_id = :userId
+    WHERE d.id = :dutchpayId
+""", nativeQuery = true)
+    DutchpayDetailProjection findDetail(@Param("dutchpayId") Long dutchpayId,
+                                        @Param("userId") Long userId);
+
+
+}

--- a/src/main/java/com/example/tiggle/repository/dutchpay/projection/DutchpayDetailProjection.java
+++ b/src/main/java/com/example/tiggle/repository/dutchpay/projection/DutchpayDetailProjection.java
@@ -1,0 +1,17 @@
+package com.example.tiggle.repository.dutchpay.projection;
+
+import java.time.LocalDateTime;
+
+public interface DutchpayDetailProjection {
+    Long getDutchpayId();
+    String getTitle();
+    String getMessage();
+    String getRequesterName();
+    Integer getParticipantCount();
+    Long getTotalAmount();
+    LocalDateTime getCreatedAt();
+    Long getMyAmount();          // 내 몫(올림 전)
+    Long getOriginalAmount();    // 있으면 사용, 없으면 myAmount로 대체
+    Boolean getPayMore();
+    Long getCreatorId();
+}

--- a/src/main/java/com/example/tiggle/service/dutchpay/DutchpayEventHandler.java
+++ b/src/main/java/com/example/tiggle/service/dutchpay/DutchpayEventHandler.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -20,13 +21,11 @@ public class DutchpayEventHandler {
     private final StudentRepository userRepo;
     private final FcmService fcmService;
 
-    // 필요하면 @Async("fcmAsyncExecutor") 추가 가능 (이미 비동기 인프라 있으면)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onDutchpayCreated(DutchpayCreatedEvent e) {
-        String notiTitle = e.title();
-        String notiBody = (e.message() != null && !e.message().isBlank())
-                ? e.message()
-                : "더치페이 요청이 도착했어요.";
+        final String notiTitle = e.title();
+        final String notiBody = (e.message() != null && !e.message().isBlank())
+                ? e.message() : "더치페이 요청이 도착했어요.";
 
         for (Map.Entry<Long, Long> entry : e.userShareMap().entrySet()) {
             Long userId = entry.getKey();
@@ -36,19 +35,24 @@ public class DutchpayEventHandler {
 
             var user = userRepo.findById(userId).orElse(null);
             if (user == null) continue;
-            var token = user.getFcmToken();
+
+            String token = user.getFcmToken();
             if (token == null || token.isBlank()) continue;
 
-            var data = Map.of(
-                    "type", "DUTCHPAY_REQUEST",
-                    "dutchpayId", String.valueOf(e.dutchpayId()),
-                    "title", e.title(),
-                    "message", e.message() == null ? "" : e.message(),
-                    "totalAmount", String.valueOf(e.totalAmount()),
-                    "amountToPay", String.valueOf(amountToPay)
+            Map<String, String> data = new HashMap<>();
+            data.put("type", "DUTCHPAY_REQUEST");
+            data.put("dutchpayId", String.valueOf(e.dutchpayId()));
+            data.put("totalAmount", String.valueOf(e.totalAmount()));
+            data.put("amountToPay", String.valueOf(amountToPay));
+            data.put("link", "tiggle://dutchpay/" + e.dutchpayId());
+
+            boolean ok = fcmService.sendNotificationWithData(
+                    token,
+                    notiTitle,
+                    notiBody,
+                    data
             );
 
-            boolean ok = fcmService.sendNotificationWithData(token, notiTitle, notiBody, data);
             if (!ok) {
                 log.warn("더치페이 FCM 전송 실패 userId={}, dutchpayId={}", userId, e.dutchpayId());
             }

--- a/src/main/java/com/example/tiggle/service/dutchpay/DutchpayReadService.java
+++ b/src/main/java/com/example/tiggle/service/dutchpay/DutchpayReadService.java
@@ -1,0 +1,56 @@
+package com.example.tiggle.service.dutchpay;
+
+import com.example.tiggle.dto.ResponseDto;
+import com.example.tiggle.dto.dutchpay.request.DutchpayDetailData;
+import com.example.tiggle.repository.dutchpay.DutchpayQueryRepository;
+import com.example.tiggle.repository.dutchpay.projection.DutchpayDetailProjection;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DutchpayReadService {
+
+    private final DutchpayQueryRepository queryRepo;
+
+    public ResponseDto<DutchpayDetailData> getDetail(Long dutchpayId, Long userId) {
+        DutchpayDetailProjection p = queryRepo.findDetail(dutchpayId, userId);
+        if (p == null) return new ResponseDto<>(false, "더치페이를 찾을 수 없습니다.");
+
+        boolean isCreator = p.getCreatorId() != null && p.getCreatorId().equals(userId);
+
+        // 접근 제어: 생성자가 아니면서 내 몫이 없으면 차단(필요 시 정책에 맞게 조정)
+        if (!isCreator && (p.getMyAmount() == null || p.getMyAmount() == 0L)) {
+            return new ResponseDto<>(false, "해당 더치페이에 접근 권한이 없습니다.");
+        }
+
+        long original = (p.getOriginalAmount() != null && p.getOriginalAmount() > 0)
+                ? p.getOriginalAmount()
+                : (p.getMyAmount() == null ? 0L : p.getMyAmount());
+
+        long rounded = roundUpTo100(original);      // ★ 100원 단위 올림
+        long tiggle  = Math.max(0, rounded - original);
+
+        DutchpayDetailData data = new DutchpayDetailData(
+                p.getDutchpayId(),
+                p.getTitle(),
+                p.getMessage(),
+                p.getRequesterName(),
+                p.getParticipantCount() == null ? 0 : p.getParticipantCount(),
+                p.getTotalAmount(),
+                p.getCreatedAt(),
+                rounded,                 // 내가 내는 금액(올림값)
+                original,                // 원래 금액
+                tiggle,                  // 티끌
+                p.getPayMore() != null && p.getPayMore(),
+                isCreator
+        );
+
+        return new ResponseDto<>(true, data);
+    }
+
+    private long roundUpTo100(long amount) {
+        if (amount <= 0) return 0;
+        return ((amount + 99) / 100) * 100;
+    }
+}

--- a/src/main/java/com/example/tiggle/service/sms/OtpCrypto.java
+++ b/src/main/java/com/example/tiggle/service/sms/OtpCrypto.java
@@ -1,4 +1,4 @@
-package com.example.tiggle.service;
+package com.example.tiggle.service.sms;
 
 import java.security.MessageDigest;
 import java.security.SecureRandom;

--- a/src/main/java/com/example/tiggle/service/sms/OtpStore.java
+++ b/src/main/java/com/example/tiggle/service/sms/OtpStore.java
@@ -1,4 +1,4 @@
-package com.example.tiggle.service;
+package com.example.tiggle.service.sms;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;

--- a/src/main/java/com/example/tiggle/service/sms/SmsService.java
+++ b/src/main/java/com/example/tiggle/service/sms/SmsService.java
@@ -1,4 +1,4 @@
-package com.example.tiggle.service;
+package com.example.tiggle.service.sms;
 
 import com.example.tiggle.config.SmsProps;
 import net.nurigo.sdk.message.model.Message;


### PR DESCRIPTION
## 📄 요약 (Summary)

더치페이 기능 전반(생성 → FCM 발송 → 상세 조회)을 구현/정리했습니다.

* 더치페이 생성 시 이벤트 발행 후, 커밋 완료 뒤 참여자에게 FCM 알림을 전송합니다(딥링크 포함).
* 상세 조회 API는 JWT의 사용자 기준으로 접근 권한을 검사하고, **100원 단위 올림 규칙**을 적용해 `myAmount`/`tiggleAmount`를 계산하여 반환합니다.
* 응답은 공통 `ResponseDto{ result, data, message }` 포맷을 따릅니다. Swagger 문서 추가 완료.

<br>

## 🔗 관련 이슈 (Related Issue)

* Closes OPS-108

<br>

## ✨ 주요 변경 사항 (Key Changes)

* **API**

  * `POST /api/dutchpay/requests` : 더치페이 요청 생성(저장 + FCM 발송 트리거)
  * `GET /api/dutchpay/{id}/detail` : 상세 조회(요청자 이름/메시지/요약 정보 + 내 금액, 티끌 포함)
* **이벤트/알림**

  * `DutchpayCreatedEvent`(record) 도입
  * `@TransactionalEventListener(phase = AFTER_COMMIT)` 기반 `DutchpayEventHandler` 구현

    * 생성자 제외 각 참여자 대상으로 FCM 전송
    * 메서드 인자: `title`, `message`
    * `data` 페이로드: `type=DUTCHPAY_REQUEST`, `dutchpayId`, `totalAmount`, `amountToPay`, `link=tiggle://dutchpay/{id}`
* **도메인 규칙**

  * **100원 단위 올림**: `myAmount = ceil(originalAmount/100)*100`
  * **티끌**: `tiggleAmount = myAmount - originalAmount`
  * 접근 제어: **생성자 또는 참여자**만 상세 조회 가능(미해당 시 403)
* **데이터 조회 최적화**

  * `DutchpayQueryRepository` 네이티브 쿼리 + **인터페이스 Projection** 적용
  * 테이블 조인 대상 **`users`** 로 수정(`student` → `users`)

<br>

## 🙏 리뷰어에게 (To the Reviewer)

* 추가로 필요하신 검증 항목이나 예외 케이스가 있으면 코멘트 주시면 반영하겠습니다.
