### PR TITLE
나의 성장 경험치 및 하트 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'io.spring.dependency-management' version '1.1.7'
 }
 
-group = 'com.example'
+group = 'com.ssafy'
 version = '0.0.1-SNAPSHOT'
 description = 'tiggle'
 

--- a/src/main/java/com/ssafy/tiggle/controller/donation/DonationController.java
+++ b/src/main/java/com/ssafy/tiggle/controller/donation/DonationController.java
@@ -192,4 +192,19 @@ public class DonationController {
         List<DonationRanking> response = donationService.getDepartmentRanking(userId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
+
+    /**
+     * 하트 누르기
+     *
+     * @return 학교 랭킹 목록
+     */
+    @PostMapping("/heart")
+    @Operation(summary = "하트 누르기", description = "하트를 하나 소모하고 경험치를 증가시킵니다.")
+    @ApiResponses(value = {
+    })
+    public ResponseEntity<ApiResponse<CharacterLevel>> useHeart() {
+        Long userId = JwtUtil.getCurrentUserId();
+        CharacterLevel response = donationService.useHeart(userId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
 }

--- a/src/main/java/com/ssafy/tiggle/dto/donation/response/CharacterLevel.java
+++ b/src/main/java/com/ssafy/tiggle/dto/donation/response/CharacterLevel.java
@@ -1,7 +1,6 @@
 package com.ssafy.tiggle.dto.donation.response;
 
-public record DonationGrowthLevel(
-        Long totalAmount,
+public record CharacterLevel(
 
         Long experiencePoints,
         Long toNextLevel,

--- a/src/main/java/com/ssafy/tiggle/entity/UserCharacter.java
+++ b/src/main/java/com/ssafy/tiggle/entity/UserCharacter.java
@@ -1,0 +1,40 @@
+package com.ssafy.tiggle.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserCharacter {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private Users user;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "esg_category_id", nullable = false, columnDefinition = "BIGINT DEFAULT 1")
+    private EsgCategory esgCategory;
+
+    @Column(name = "level", nullable = false, columnDefinition = "INT DEFAULT 1")
+    private Integer level;
+
+    @Column(name = "experience_points", nullable = false, columnDefinition = "BIGINT DEFAULT 0")
+    private Long experiencePoints;
+
+    @Column(name = "heart", nullable = false, columnDefinition = "INT DEFAULT 0")
+    private Integer heart;
+
+    public void addHeart(Long amount) {
+        long heart = amount / 200;
+        this.heart += (int) heart;
+    }
+}

--- a/src/main/java/com/ssafy/tiggle/repository/donation/UserCharacterRepository.java
+++ b/src/main/java/com/ssafy/tiggle/repository/donation/UserCharacterRepository.java
@@ -1,0 +1,13 @@
+package com.ssafy.tiggle.repository.donation;
+
+import com.ssafy.tiggle.entity.UserCharacter;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserCharacterRepository extends JpaRepository<UserCharacter, Long> {
+
+    Optional<UserCharacter> findByUserId(Long userId);
+}

--- a/src/main/java/com/ssafy/tiggle/repository/piggybank/PiggyBankRepository.java
+++ b/src/main/java/com/ssafy/tiggle/repository/piggybank/PiggyBankRepository.java
@@ -1,7 +1,10 @@
 package com.ssafy.tiggle.repository.piggybank;
 
 import com.ssafy.tiggle.entity.PiggyBank;
-import org.springframework.data.jpa.repository.*;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.math.BigDecimal;

--- a/src/main/java/com/ssafy/tiggle/service/auth/AuthServiceImpl.java
+++ b/src/main/java/com/ssafy/tiggle/service/auth/AuthServiceImpl.java
@@ -2,10 +2,10 @@ package com.ssafy.tiggle.service.auth;
 
 import com.ssafy.tiggle.dto.finopenapi.response.UserResponse;
 import com.ssafy.tiggle.dto.auth.JoinRequestDto;
-import com.ssafy.tiggle.entity.Department;
-import com.ssafy.tiggle.entity.Users;
-import com.ssafy.tiggle.entity.University;
+import com.ssafy.tiggle.entity.*;
 import com.ssafy.tiggle.exception.auth.AuthException;
+import com.ssafy.tiggle.repository.donation.UserCharacterRepository;
+import com.ssafy.tiggle.repository.esg.EsgCategoryRepository;
 import com.ssafy.tiggle.repository.university.DepartmentRepository;
 import com.ssafy.tiggle.repository.user.StudentRepository;
 import com.ssafy.tiggle.repository.university.UniversityRepository;
@@ -31,6 +31,8 @@ public class AuthServiceImpl implements AuthService {
     private final StudentRepository studentRepository;
     private final UniversityRepository universityRepository;
     private final DepartmentRepository departmentRepository;
+    private final UserCharacterRepository userCharacterRepository;
+    private final EsgCategoryRepository esgCategoryRepository;
     private final PasswordEncoder passwordEncoder;
     private final FinancialApiService financialApiService;
     private final EncryptionService encryptionService;
@@ -106,6 +108,25 @@ public class AuthServiceImpl implements AuthService {
         } catch (Exception e) {
             logger.error("사용자 정보 저장 실패: {}", requestDto.getEmail(), e);
             throw AuthException.externalApiFailure("DB 사용자 정보 저장 중 오류가 발생했습니다.", e);
+        }
+
+        EsgCategory defaultCategory = esgCategoryRepository.findById(1L)
+                .orElseThrow(() -> new IllegalArgumentException("기본 ESG 카테고리가 존재하지 않습니다."));
+
+        // 7. 캐릭터 생성
+        UserCharacter userCharacter = UserCharacter.builder()
+                .user(user)
+                .esgCategory(defaultCategory)
+                .level(1)
+                .experiencePoints(0L)
+                .heart(0)
+                .build();
+
+        try {
+            userCharacterRepository.save(userCharacter);
+        } catch (Exception e) {
+            logger.error("사용자 캐릭터 저장 실패: {}", requestDto.getEmail(), e);
+            throw AuthException.externalApiFailure("DB 사용자 캐릭터 저장 중 오류가 발생했습니다.", e);
         }
     }
 

--- a/src/main/java/com/ssafy/tiggle/service/donation/DonationService.java
+++ b/src/main/java/com/ssafy/tiggle/service/donation/DonationService.java
@@ -36,4 +36,7 @@ public interface DonationService {
 
     @Transactional(readOnly = true)
     void updateRankingCache();
+
+    @Transactional
+    CharacterLevel useHeart(Long userId);
 }


### PR DESCRIPTION
## 📄 요약 (Summary)
- 나의 성장 경험치 및 하트 추가

<br>

## 🔗 관련 이슈 (Related Issue)
- Closes OPS-146
 
<br>

## ✨ 주요 변경 사항 (Key Changes)
- 기부 탭에서 기부할 시 하트 지급
- 나의 성장 조회 시 경험치, 하트 함께 조회
- 하트 누르기 API 구현
- 회원가입 시 나의 성장 캐릭터 자동 생성
- 유저 캐릭터 엔티티 추가

<br>

## 🙏 리뷰어에게 (To the Reviewer)
- 나의 성장 조회 API 응답이 변경되었습니다
- 유저 캐릭터 테이블이 추가되었습니다